### PR TITLE
Add Nix Flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,34 @@ arguments:
   -v	Prints version info
   -t	Set revealer transition duration (0 = disabled)
 ```
+
+# Nix
+
+syspower can be installed on NixOS using the flake in this repository.
+
+```nix
+{
+  inputs.syspower.url = "github:System64fumo/syspower";
+
+  # in system config...
+  environment.systemPackages = [inputs.syspower.packages.x86_64-linux.default];
+}
+```
+
+It can also be configured with Home Manager:
+
+```nix
+{
+  imports = [inputs.syspower.modules.homeManager.default];
+
+  programs.syspower = {
+    enable = true;
+    settings  {
+      position = "center";
+      monitor = 0;
+      revealer-transition-duration = 1000;
+    };
+    style = builtins.readFile ./style.css;
+  }
+}
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733581040,
+        "narHash": "sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "22c3f2cf41a0e70184334a958e6b124fb0ce3e01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1733096140,
+        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,34 +5,83 @@
   };
 
   outputs = {flake-parts, ...} @ inputs:
-    flake-parts.lib.mkFlake {inherit inputs;} {
+    flake-parts.lib.mkFlake {inherit inputs;} rec {
+      imports = [flake-parts.flakeModules.modules];
+
       systems = ["x86_64-linux"];
+
+      flake.overlays.default = final: prev: {
+        syspower = prev.callPackage ./package.nix {};
+      };
+
+      flake.modules.homeManager.default = {
+        config,
+        lib,
+        pkgs,
+        ...
+      }: let
+        inherit (lib) mkEnableOption mkPackageOption mkOption types mkIf;
+        cfg = config.programs.syspower;
+      in {
+        options.programs.syspower = {
+          enable = mkEnableOption "Syspower";
+          package = mkPackageOption pkgs "syspower" {};
+          settings = {
+            position = mkOption {
+              type = types.enum ["top" "right" "bottom" "left" "center"];
+              default = "center";
+              description = "Position of the menu on the screen";
+            };
+            monitor = mkOption {
+              type = types.int;
+              default = 0;
+              description = "Monitor on which to show the menu";
+            };
+            transition-duration = mkOption {
+              type = types.int;
+              default = 1000;
+              description = "Reveal transition duration in milliseconds";
+            };
+          };
+          style = mkOption {
+            type = (pkgs.formats.css {}).type;
+            default = builtins.readFile ./style.css;
+            description = "CSS stylesheet to apply to the menu";
+          };
+        };
+
+        config = mkIf cfg.enable {
+          home.packages = [cfg.package];
+
+          nixpkgs.overlays = [flake.overlays.default];
+
+          home.file = {
+            ".config/sys64/power/config.conf".text = ''
+              [main]
+              position=${with cfg.settings;
+                if position == "top"
+                then 0
+                else if position == "right"
+                then 1
+                else if position == "bottom"
+                then 2
+                else if position == "left"
+                then 3
+                else 4}
+              monitor=${cfg.settings.monitor}
+              transition-duration=${cfg.settings.transition-duration}
+            '';
+            ".config/sys64/power/style.css".text = cfg.style;
+          };
+        };
+      };
+
       perSystem = {
         pkgs,
         lib,
         ...
-      }: let
-      in rec {
-        packages.default = pkgs.stdenv.mkDerivation {
-          name = "syspower";
-          src = ./.;
-          buildInputs = with pkgs; [gtkmm4 gtk4-layer-shell];
-          nativeBuildInputs = with pkgs; [
-            pkg-config
-            makeWrapper
-          ];
-
-          buildPhase = ''
-            make
-          '';
-
-          installPhase = ''
-            install -D -t $out/bin syspower
-            install -D -t $out/lib libsyspower.so
-            install -D -t $out/share/sys64/power config.conf style.css
-            wrapProgram $out/bin/syspower --prefix LD_LIBRARY_PATH : $out/lib
-          '';
-        };
+      }: rec {
+        packages.default = pkgs.callPackage ./package.nix {};
 
         devShells.default = pkgs.mkShell {
           inputsFrom = [packages.default];

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
           home.file = {
             ".config/sys64/power/config.conf".text = ''
               [main]
-              position=${with cfg.settings;
+              position=${builtins.toString (with cfg.settings;
                 if position == "top"
                 then 0
                 else if position == "right"
@@ -67,9 +67,9 @@
                 then 2
                 else if position == "left"
                 then 3
-                else 4}
-              monitor=${cfg.settings.monitor}
-              transition-duration=${cfg.settings.transition-duration}
+                else 4)}
+              monitor=${builtins.toString.settings.monitor}
+              transition-duration=${builtins.toString.settings.transition-duration}
             '';
             ".config/sys64/power/style.css".text = cfg.style;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -68,8 +68,8 @@
                 else if position == "left"
                 then 3
                 else 4)}
-              monitor=${builtins.toString.settings.monitor}
-              transition-duration=${builtins.toString.settings.transition-duration}
+              monitor=${builtins.toString cfg.settings.monitor}
+              transition-duration=${builtins.toString cfg.settings.transition-duration}
             '';
             ".config/sys64/power/style.css".text = cfg.style;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = {flake-parts, ...} @ inputs:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux"];
+      perSystem = {
+        pkgs,
+        lib,
+        ...
+      }: let
+      in rec {
+        packages.default = pkgs.stdenv.mkDerivation {
+          name = "syspower";
+          src = ./.;
+          buildInputs = with pkgs; [gtkmm4 gtk4-layer-shell];
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            makeWrapper
+          ];
+
+          buildPhase = ''
+            make
+          '';
+
+          installPhase = ''
+            install -D -t $out/bin syspower
+            install -D -t $out/lib libsyspower.so
+            install -D -t $out/share/sys64/power config.conf style.css
+            wrapProgram $out/bin/syspower --prefix LD_LIBRARY_PATH : $out/lib
+          '';
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [packages.default];
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
             };
           };
           style = mkOption {
-            type = (pkgs.formats.css {}).type;
+            type = types.str;
             default = builtins.readFile ./style.css;
             description = "CSS stylesheet to apply to the menu";
           };

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,21 @@
+{pkgs, ...}:
+pkgs.stdenv.mkDerivation {
+  name = "syspower";
+  src = ./.;
+  buildInputs = with pkgs; [gtkmm4 gtk4-layer-shell];
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    install -D -t $out/bin syspower
+    install -D -t $out/lib libsyspower.so
+    install -D -t $out/share/sys64/power config.conf style.css
+    wrapProgram $out/bin/syspower --prefix LD_LIBRARY_PATH : $out/lib
+  '';
+}


### PR DESCRIPTION
This allows NixOS users to install and use Syspower, as well as providing options for configuring the app with Nix via Home Manager.

I'm currently successfully using this flake to run and configure syspower on my computer.