### PR TITLE
Hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ arguments:
   -m	Set primary monitor (If you have multiple monitors)
   -v	Prints version info
   -t	Set revealer transition duration (0 = disabled)
+  -k	Set a hotkey (name,action - e.g. x,cancel)
 ```

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -4,10 +4,14 @@
 #define CONFIG_FILE			// Allow the use of a config file
 #define CONFIG_RUNTIME			// Allow the use of runtime arguments
 
+#include <unordered_map>
+#include <gtkmm.h>
+
 // Default config
 struct config_power {
 	int position = 4;
 	int main_monitor = 0;
 	int transition_duration = 1000;
+	std::unordered_map<guint, std::string> hotkeys;
 };
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 // Build time configuration		Description
-#define CONFIG_FILE				// Allow the use of a config file
+#define CONFIG_FILE			// Allow the use of a config file
 #define CONFIG_RUNTIME			// Allow the use of runtime arguments
 
 // Default config

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -17,7 +17,8 @@ struct config_power {
 		{GDK_KEY_r, "reboot"},
 		{GDK_KEY_l, "logout"},
 		{GDK_KEY_s, "suspend"},
-		{GDK_KEY_c, "cancel"}
+		{GDK_KEY_c, "cancel"},
+		{GDK_KEY_Escape, "cancel"}
 	};
 };
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -12,6 +12,12 @@ struct config_power {
 	int position = 4;
 	int main_monitor = 0;
 	int transition_duration = 1000;
-	std::unordered_map<guint, std::string> hotkeys;
+	std::unordered_map<guint, std::string> hotkeys = {
+		{GDK_KEY_u, "shutdown"},
+		{GDK_KEY_r, "reboot"},
+		{GDK_KEY_l, "logout"},
+		{GDK_KEY_s, "suspend"},
+		{GDK_KEY_c, "cancel"}
+	};
 };
 

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -6,6 +6,7 @@ config_parser::config_parser(const std::string &filename) {
 	std::ifstream file(filename);
 	std::string line;
 	std::string current_section;
+	int n_hotkeys;
 
 	available = file.is_open();
 
@@ -17,16 +18,26 @@ config_parser::config_parser(const std::string &filename) {
 				continue;
 			}
 			else if (line[0] == '[' && line[line.size() - 1] == ']') {
+				if (!current_section.empty()) {
+					data[current_section]["n_hotkeys"] = std::to_string(n_hotkeys);
+				}
 				current_section = line.substr(1, line.size() - 2);
+				n_hotkeys = 0;
 			}
 			else {
 				size_t delimiter_pos = line.find('=');
 				if (delimiter_pos != std::string::npos) {
 					std::string key = trim(line.substr(0, delimiter_pos));
 					std::string value = trim(line.substr(delimiter_pos + 1));
+					if (key == "hotkey") {
+						key += std::to_string(++n_hotkeys);
+					}
 					data[current_section][key] = value;
 				}
 			}
+		}
+		if (!current_section.empty()) {
+			data[current_section]["n_hotkeys"] = std::to_string(n_hotkeys);
 		}
 		file.close();
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "git_info.hpp"
 
 #include <gtkmm/application.h>
+#include <gtkmm.h>
 #include <filesystem>
 #include <dlfcn.h>
 
@@ -48,6 +49,15 @@ int main(int argc, char *argv[]) {
 		std::string cfg_transition =  config.data["main"]["transition-duration"];
 		if (!cfg_transition.empty())
 			config_main.transition_duration =std::stoi(cfg_transition);
+		int n_hotkeys = std::stoi(config.data["main"]["n_hotkeys"]);
+		for (int i = 0; i < n_hotkeys; ++i) {
+			std::string hotkey = config.data["main"]["hotkey" + std::to_string(i + 1)];
+			size_t comma_pos = hotkey.find(',');
+			std::string keyname = hotkey.substr(0, comma_pos);
+			guint keyval = gdk_keyval_from_name(keyname.c_str());
+			hotkey.erase(0, comma_pos + 1);
+			config_main.hotkeys[keyval] = hotkey;
+		}
 	}
 	#endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,6 +111,7 @@ int main(int argc, char *argv[]) {
 				std::printf("  -p	Set position\n");
 				std::printf("  -m	Set primary monitor\n");
 				std::printf("  -t	Set revealer transition duration\n");
+				std::printf("  -k	Set a hotkey (name,action - e.g. x,cancel)\n");
 				std::printf("  -v	Prints version info\n");
 				std::printf("  -h	Show this help message\n");
 				return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
 	// Read launch arguments
 	#ifdef CONFIG_RUNTIME
 	while (true) {
-		switch(getopt(argc, argv, "p:dm:dt:dvh")) {
+		switch(getopt(argc, argv, "p:dm:dt:dvhk:")) {
 			case 'p':
 				config_main.position = std::stoi(optarg);
 				if (config_main.position > 4 || config_main.position < 0) {
@@ -93,7 +93,16 @@ int main(int argc, char *argv[]) {
 				std::printf("Commit: %s\n", GIT_COMMIT_MESSAGE);
 				std::printf("Date: %s\n", GIT_COMMIT_DATE);
 				return 0;
-
+			case 'k':
+				{
+					std::string hotkey = optarg;
+					size_t comma_pos = hotkey.find(',');
+					std::string keyname = hotkey.substr(0, comma_pos);
+					guint keyval = gdk_keyval_from_name(keyname.c_str());
+					hotkey.erase(0, comma_pos + 1);
+					config_main.hotkeys[keyval] = hotkey;
+				}
+				continue;
 			case 'h':
 			default :
 				std::printf("usage:\n");

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -103,10 +103,7 @@ syspower::syspower(const config_power& cfg) : config_main(cfg) {
 	auto key_controller = Gtk::EventControllerKey::create();
 	key_controller->signal_key_pressed().connect(
 		[this](guint keyval, guint, Gdk::ModifierType) {
-			if (keyval == GDK_KEY_Escape) {
-				on_button_clicked("cancel");
-				return true;
-			} else if (!config_main.hotkeys[keyval].empty()) {
+			if (!config_main.hotkeys[keyval].empty()) {
 				on_button_clicked(config_main.hotkeys[keyval]);
 				return true;
 			}

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -106,6 +106,9 @@ syspower::syspower(const config_power& cfg) : config_main(cfg) {
 			if (keyval == GDK_KEY_Escape) {
 				on_button_clicked("cancel");
 				return true;
+			} else if (!config_main.hotkeys[keyval].empty()) {
+				on_button_clicked(config_main.hotkeys[keyval]);
+				return true;
 			}
 			return false;
 		},

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -212,15 +212,15 @@ void syspower::action_thread() {
 
 void syspower::add_button(const std::string& label) {
 	Gtk::Button *button = Gtk::make_managed<Gtk::Button>(label);
-	std::string lowecase = label;
-	for (char& c : lowecase)
+	std::string lowercase = label;
+	for (char& c : lowercase)
 		c = std::tolower(static_cast<unsigned char>(c));
 	button->set_size_request(300, 75);
 	button->set_margin(5);
-	button->get_style_context()->add_class("button_" + lowecase);
+	button->get_style_context()->add_class("button_" + lowercase);
 	box_buttons.append(*button);
-	button->signal_clicked().connect([this, lowecase]() {
-		on_button_clicked(lowecase);
+	button->signal_clicked().connect([this, lowercase]() {
+		on_button_clicked(lowercase);
 	});
 }
 


### PR DESCRIPTION
Adds configurable hotkeys. You can bind any key to one of the 5 buttons by setting the `hotkey` option in the config file or passing the `-k` flag on the command line one or more times. The format is `key,action`, where `key` is a valid GDK key name, and `action` is one of the buttons. For example, adding `hotkey=x,cancel` in the config file would bind `x` to the Cancel button.

This PR replaces the hard-coded escape-to-close functionality with a new default hotkey binding `Escape` to `cancel`.