### PR TITLE
Imrpove command handling in case elogind is used instead of systemd

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -97,6 +97,7 @@ syspower::syspower(const std::map<std::string, std::map<std::string, std::string
 	add_button("Reboot");
 	add_button("Logout");
 	add_button("Suspend");
+	add_button("Hibernate");
 	add_button("Cancel");
 
 	// Key events
@@ -254,6 +255,13 @@ void syspower::on_button_clicked(const std::string& button) {
 	else if (button == "suspend") {
 		button_text = "Suspending...";
 		system("systemctl suspend");
+		for (const auto &window : windows)
+			window->close();
+		close();
+	}
+	else if (button == "hibernate") {
+		button_text = "Hibernating...";
+		system("systemctl hibernate");
 		for (const auto &window : windows)
 			window->close();
 		close();

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -254,14 +254,14 @@ void syspower::on_button_clicked(const std::string& button) {
 	}
 	else if (button == "suspend") {
 		button_text = "Suspending...";
-		system("systemctl suspend");
+		system((cmd + " suspend").c_str());
 		for (const auto &window : windows)
 			window->close();
 		close();
 	}
 	else if (button == "hibernate") {
 		button_text = "Hibernating...";
-		system("systemctl hibernate");
+		system((cmd + " hibernate").c_str());
 		for (const auto &window : windows)
 			window->close();
 		close();


### PR DESCRIPTION
I'm using Gentoo and even though my installation is systemd based, there are OpenRC based installations which use elogind to enable Gnome and KDE run on OpenRC, so if this is run on an elogind based system it should use loginctl instead of systemctl. Elogind has those verbs integrated into the loginctl command. So far I've only tested it with systemd, but I don't see where it could fail if elogind was the seat manager, so I believe it'll work that way.